### PR TITLE
Clean-up and fix HTTP Executor

### DIFF
--- a/core/src/main/scala/http.scala
+++ b/core/src/main/scala/http.scala
@@ -20,54 +20,52 @@ import scala.concurrent._
 import com.ning.http.client._
 import org.jboss.netty.util._
 import org.jboss.netty.channel.socket.nio._
-trait Executor {
-  def client: AsyncHttpClient
-  def apply[A](request: Request, handler: AsyncHandler[A])(implicit ec: ExecutionContext): Future[A] = {
+import java.util.{ concurrent => juc }
+
+object Executor {
+  private lazy val (providerConfig, threadPool) = {
+    // Setup the underlying Netty Provider to:
+    //   1) Use daemon threads
+    //   2) Release resources at interruption
+    lazy val threadFactory: juc.ThreadFactory = new juc.ThreadFactory {
+      val once = new juc.atomic.AtomicBoolean(false)
+      def newThread(runnable: Runnable) = new Thread(runnable) {
+        setDaemon(true)
+        override def interrupt() = {
+          if (once.compareAndSet(false, true)) {
+            channelFactory.releaseExternalResources()
+            timer.stop()
+          }
+          super.interrupt()
+        }
+      }
+    }
+    lazy val threadPool: juc.Executor = juc.Executors.newCachedThreadPool(threadFactory)
+    lazy val timer = new HashedWheelTimer(threadFactory)
+    lazy val channelFactory: NioClientSocketChannelFactory = new NioClientSocketChannelFactory(threadPool, 1,
+      new NioWorkerPool(threadPool, Runtime.getRuntime.availableProcessors * 2), timer)
+    val providerConfig = new NettyAsyncHttpProviderConfig().addProperty(NettyAsyncHttpProviderConfig.SOCKET_CHANNEL_FACTORY, channelFactory)
+    providerConfig.setNettyTimer(timer)
+    (providerConfig, threadPool)
+  }
+}
+
+import Executor._
+
+case class ExecutorOptions(userAgent: String = s"Mozilla/5.0 (compatible; scarango/${BuildInfo.version}}; +https://github.com/sumito3478/scarango)")
+
+case class Executor(options: ExecutorOptions = ExecutorOptions()) extends Disposable {
+  lazy val client = new AsyncHttpClient(new AsyncHttpClientConfig.Builder()
+    .setAsyncHttpClientProviderConfig(providerConfig)
+    .setUserAgent(options.userAgent)
+    .setRequestTimeoutInMs(-1).build)
+  def apply[A](request: Request, handler: AsyncHandler[A]): Future[A] = {
     val jfuture = client.executeRequest(request, handler)
     val p = Promise[A]()
     jfuture.addListener(new Runnable {
       def run = p.complete(scala.util.Try(jfuture.get))
-    }, new java.util.concurrent.Executor {
-      def execute(runnable: Runnable) = {
-        ec.execute(runnable)
-      }
-    })
+    }, threadPool)
     p.future
   }
-}
-object Executor {
-  val defaultUserAgent = s"Mozilla/5.0 (compatible; scarango/${BuildInfo.version}}; +https://github.com/sumito3478/scarango)"
-  def apply(client: AsyncHttpClient): Executor = {
-    val c = client
-    new Executor {
-      def client = c
-    }
-  }
-  def apply(userAgent: String = defaultUserAgent): Executor with Disposable = {
-    val builder = (if ((for (group <- Option(Thread.currentThread.getThreadGroup)) yield group.getName == "trap.exit") == Some(true)) {
-      // sbt-interactive session
-      class ThreadFactory(shutdown: () => Unit) extends java.util.concurrent.ThreadFactory {
-        def newThread(runnable: Runnable) = new Thread(runnable) {
-          setDaemon(true)
-          override def interrupt = {
-            shutdown()
-            super.interrupt
-          }
-        }
-      }
-      lazy val shuttingDown = new java.util.concurrent.atomic.AtomicBoolean(false)
-      lazy val threadFactory: ThreadFactory = new ThreadFactory(() => if (shuttingDown.compareAndSet(false, true)) channelFactory.releaseExternalResources)
-      lazy val channelFactory: NioClientSocketChannelFactory = new NioClientSocketChannelFactory(java.util.concurrent.Executors.newCachedThreadPool(threadFactory), 1,
-        new NioWorkerPool(java.util.concurrent.Executors.newCachedThreadPool(threadFactory), Runtime.getRuntime.availableProcessors * 2), new HashedWheelTimer(new ThreadFactory(() => ())))
-      new AsyncHttpClientConfig.Builder()
-        .setAsyncHttpClientProviderConfig(new NettyAsyncHttpProviderConfig().addProperty(NettyAsyncHttpProviderConfig.SOCKET_CHANNEL_FACTORY, channelFactory))
-    } else {
-      new AsyncHttpClientConfig.Builder()
-    }).setUserAgent(userAgent)
-      .setRequestTimeoutInMs(-1)
-    new Executor with Disposable {
-      lazy val client = new AsyncHttpClient(builder.build)
-      def disposeInternal = client.close
-    }
-  }
+  override def disposeInternal() = client.close()
 }


### PR DESCRIPTION
1. Every Executor is now Disposable and owns one underlying AsyncHttpClient.
   Copying Executor just copies settings and AsyncHttpClient is created for every Executor (lazily).
2. Execute `providerConfig.setNettyTimer(timer)` to ensure every thread used by Netty is daemon,
   and fix JVM hang-up on exit. _This will fix the hang-up on exiting sbt console_.
